### PR TITLE
Make `ApiClient` injectable

### DIFF
--- a/src/client/http.js
+++ b/src/client/http.js
@@ -32,8 +32,8 @@ function byteArrayToLong(/*byte[]*/byteArray) {
 
 class ApiClient {
 
-  constructor() {
-    this.apiUrl = process.env.API_URL;
+  constructor(apiUrl) {
+    this.apiUrl = apiUrl || process.env.API_URL;
     this.signer = null;
   }
 


### PR DESCRIPTION
Because not all app can environment variable `API_URL`. For example, create-react-app can't set that variable. To make `apiUrl` be injectable for `ApiClient`, we can pass in a parameter `apiUrl`. If that's `null` or `undefined`, it won't change any behaviour as current. So there is no breaking changes.