### PR TITLE
 fix bug with Babel 6 ES2015 compilation

### DIFF
--- a/src/utils/crypto.js
+++ b/src/utils/crypto.js
@@ -48,9 +48,9 @@ function signBytes(privateKey, contents) {
   }
 
   let hashBytes = SHA256(contents);
-  let signBytes = ECKeySign(hashBytes, privateKey);
+  let signedBytes = ECKeySign(hashBytes, privateKey);
 
-  return signBytes;
+  return signedBytes;
 }
 
 //return bytes of rowdata, use to sign.


### PR DESCRIPTION
Fix bug with Babel 6 ES2015 compilation: variable declared in method with the same name causes "duplicate declaration" error.
https://github.com/babel/babel/issues/2684