### PR TITLE
Move testing tools out of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,20 +32,22 @@
   "bundleDependencies": false,
   "dependencies": {
     "axios": "^0.18.0",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-env": "^1.7.0",
-    "babel-preset-es2015": "^6.24.1",
     "base-58": "^0.0.1",
     "btoa": "^1.2.1",
-    "chai": "^4.1.2",
     "crypto-js": "^3.1.9-1",
     "elliptic": "^6.4.0",
     "google-protobuf": "^3.5.0",
     "js-sha3": "^0.7.0",
-    "mocha": "^5.1.0",
     "nano-time": "^1.0.0",
     "qs": "^6.5.1"
+  },
+  "devDependencies": {
+    "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-es2015": "^6.24.1",
+    "chai": "^4.1.2",
+    "mocha": "^5.1.0"
   },
   "deprecated": false,
   "description": "Tronscan API Client",


### PR DESCRIPTION
Mocha and Chai are used for unit-testing during development. Since people don't need these packages at run-time, move them to devDependencies.